### PR TITLE
Revert "Bump setuptools-scm[toml] from 8.3.1 to 9.2.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -149,9 +149,9 @@ pyproject-hooks==1.2.0 \
     #   -r requirements.in
     #   build
     #   pip-tools
-setuptools-scm[toml]==9.2.0 \
-    --hash=sha256:6662c9b9497b6c9bf13bead9d7a9084756f68238302c5ed089fb4dbd29d102d7 \
-    --hash=sha256:c551ef54e2270727ee17067881c9687ca2aedf179fa5b8f3fab9e8d73bdc421f
+setuptools-scm[toml]==8.3.1 \
+    --hash=sha256:332ca0d43791b818b841213e76b1971b7711a960761c5bea5fc5cdb5196fbce3 \
+    --hash=sha256:3d555e92b75dacd037d32bafdf94f97af51ea29ae8c7b234cf94b7a5bd242a63
     # via
     #   -r requirements.in
     #   ozi-build


### PR DESCRIPTION
This reverts commit d91f5636b9263fd8368c763e26ba226b950e9188.

Signed-off-by: Eden Ross Duff MSc <rjdbcm@outlook.com>